### PR TITLE
Feature/neos 8 compatibility

### DIFF
--- a/Classes/Service/NodeService.php
+++ b/Classes/Service/NodeService.php
@@ -122,17 +122,17 @@ class NodeService
      */
     public function findOrCreateBetterEmbedAssetCollection(string $title = self::ASSET_COLLECTION_TITLE): AssetCollection
     {
-        /** @var AssetCollection $asseteCollection */
-        $asseteCollection = $this->assetCollectionRepository->findByTitle($title)->getFirst();
+        /** @var AssetCollection $assetCollection */
+        $assetCollection = $this->assetCollectionRepository->findByTitle($title)->getFirst();
 
-        if ($asseteCollection == null) {
-            $asseteCollection = new AssetCollection($title);
+        if ($assetCollection === null) {
+            $assetCollection = new AssetCollection($title);
 
-            $this->assetCollectionRepository->add($asseteCollection);
-            $this->persistenceManager->whitelistObject($asseteCollection);
+            $this->assetCollectionRepository->add($assetCollection);
+            $this->persistenceManager->allowObject($assetCollection);
         }
 
-        return $asseteCollection;
+        return $assetCollection;
     }
 
     /**
@@ -174,7 +174,7 @@ class NodeService
         $tag->setAssetCollections($assetCollections);
 
         $this->tagRepository->add($tag);
-        $this->persistenceManager->whitelistObject($tag);
+        $this->persistenceManager->allowObject($tag);
 
         return $tag;
     }

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         "source": "https://github.com/betterembed/neos-betterembed"
     },
     "require": {
-        "neos/neos": "^4.3 || ^5 || ^7 || ^8",
+        "neos/neos": "^8",
         "guzzlehttp/guzzle": "^6.3"
     },
     "authors": [

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         "source": "https://github.com/betterembed/neos-betterembed"
     },
     "require": {
-        "neos/neos": "^4.3 || ^5 || ^7",
+        "neos/neos": "^4.3 || ^5 || ^7 || ^8",
         "guzzlehttp/guzzle": "^6.3"
     },
     "authors": [


### PR DESCRIPTION
This PR consists of three changes:

1. composer.json only allows neos 8
2. In Neos 8 the method `whitelistObject` had been replaced by `allowObject` (see https://github.com/neos/flow-development-collection/releases/tag/8.0.0). This is the reason why the minimum requirement now is Neos 8.
3. A minor typo in a variable name

