### PR TITLE
Pass node dimensions into context on nodeUpdated

### DIFF
--- a/Classes/Service/EmbedService.php
+++ b/Classes/Service/EmbedService.php
@@ -99,7 +99,10 @@ class EmbedService
      */
     public function nodeUpdated(NodeInterface $node): void
     {
-
+        $this->context = $this->contextFactory->create([
+            'workspaceName' => 'live',
+            'dimensions' => $node->getDimensions()
+        ]);
         if ($node->getNodeType()->isOfType('BetterEmbed.NeosEmbed:Mixin.Item')) {
             $url = $node->getProperty('url');
 


### PR DESCRIPTION
Makes BetterEmbed nodes work in multiple content dimensions.

See #27 