### PR TITLE
Fix: #30 Root Node Usage to Find BetterEmbed Nodes

### DIFF
--- a/Classes/Service/EmbedService.php
+++ b/Classes/Service/EmbedService.php
@@ -2,6 +2,7 @@
 
 namespace BetterEmbed\NeosEmbed\Service;
 
+use BetterEmbed\NeosEmbed\Domain\Repository\BetterEmbedRepository;
 use GuzzleHttp\Exception\GuzzleException;
 use Neos\ContentRepository\Domain\Model\NodeType;
 use Neos\ContentRepository\Exception\NodeException;
@@ -144,7 +145,7 @@ class EmbedService
     public function getByUrl(string $url, $createIfNotFound = false)
     {
         /** @var NodeInterface $record */
-        $node = $this->nodeService->findRecordByUrl($this->context->getRootNode(), $url);
+        $node = $this->nodeService->findRecordByUrl($this->context->getNode('/' . BetterEmbedRepository::BETTER_EMBED_ROOT_NODE_NAME), $url);
 
         if ($node == null && $createIfNotFound) {
 


### PR DESCRIPTION
This fixes #30 in that the original looks in the root node of neos for the Better Embed nodes however they are created under the better embed root node.

This updates the service to find the record by Url under the correct Better Embed root node. This should also minimize the number of requests to the better embed API.